### PR TITLE
用户配置深拷贝

### DIFF
--- a/dist/dropload.js
+++ b/dist/dropload.js
@@ -32,7 +32,7 @@
     // 初始化
     MyDropLoad.prototype.init = function(options){
         var me = this;
-        me.opts = $.extend({}, {
+        me.opts = $.extend(true, {}, {
             scrollArea : me.$element,                                            // 滑动区域
             domUp : {                                                            // 上方DOM
                 domClass   : 'dropload-up',


### PR DESCRIPTION
当用户自定义配置时，进行深拷贝，用户只需重写自己想重写的配置
例如：用户想自定义domNoData为`<div class="dropload-noData">没有更多数据了</div>`.
当前做法：

``` javascript
domDown : {
                domClass   : 'dropload-down',
                domRefresh : '<div class="dropload-refresh">↑上拉加载更多</div>',
                domLoad    : '<div class="dropload-load"><span class="loading"></span>加载中...</div>',
                domNoData  : '<div class="dropload-noData">没有更多数据了</div>'
}
```

现在可以：

``` javascript
domDown : {
                domNoData  : '<div class="dropload-noData">没有更多数据了</div>'
}
```
