### PR TITLE
解决不使用上拉加载，js报错问题

### DIFF
--- a/dist/dropload.js
+++ b/dist/dropload.js
@@ -221,10 +221,12 @@
 
     // 加载下方
     function loadDown(me){
-        me.direction = 'up';
-        me.$domDown.html(me.opts.domDown.domLoad);
-        me.loading = true;
-        me.opts.loadDownFn(me);
+        if (me.opts.loadDownFn != '') {
+            me.direction = 'up';
+            me.$domDown.html(me.opts.domDown.domLoad);
+            me.loading = true;
+            me.opts.loadDownFn(me);
+        }
     }
 
     // 锁定


### PR DESCRIPTION
当我不使用 loadDown 时，js 会报错
`Uncaught TypeError: Cannot read property 'html' of undefinedloadDown @ dropload.js:`
