### PR TITLE
fixed Issue #68 修复下拉刷新后无法再加载更多的问题

### DIFF
--- a/dist/dropload.js
+++ b/dist/dropload.js
@@ -287,6 +287,7 @@
                 me.upInsertDOM = false;
                 $(this).remove();
                 fnRecoverContentHeight(me);
+                fnAutoLoad(me);
             });
         }else if(me.direction == 'up'){
             me.loading = false;


### PR DESCRIPTION
下拉刷新后，若单页数据无法占满显示区域，上拉直接被锁定，无法加载更多数据