### PR TITLE
在外层暴露一个更新高度的方法

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/dist/dropload.js
+++ b/dist/dropload.js
@@ -303,6 +303,11 @@
         }
     };
 
+    MyDropLoad.prototype.fnRecoverContentHeight=function () {
+        var me=this;
+        fnRecoverContentHeight(me);
+    }
+
     // css过渡
     function fnTransition(dom,num){
         dom.css({


### PR DESCRIPTION
针对部分item需要折叠、展开的用户，如果高度不能在折叠/展开后及时更新，上拉加载更多就会失效。暴露一个方法到外层，有利于控件的拓展。
使用prototype方法暴露一个内部方法。